### PR TITLE
Set luigi to only retry once after initial run

### DIFF
--- a/luigi.cfg
+++ b/luigi.cfg
@@ -7,3 +7,4 @@ logging_conf_file = /etc/luigi/luigi-interface-logger.ini
 
 [scheduler]
 state-path = luigi-state.pickle
+disable_failures = 2


### PR DESCRIPTION
When disable failures is set to 2, the scheduler will only try to retry failed jobs once. This is better than defaulting to 999999999 😺