### PR TITLE
The scheduler is complicated

### DIFF
--- a/luigi.cfg
+++ b/luigi.cfg
@@ -8,3 +8,4 @@ logging_conf_file = /etc/luigi/luigi-interface-logger.ini
 [scheduler]
 state-path = luigi-state.pickle
 disable_failures = 2
+disable-window-seconds = 14400

--- a/luigi.cfg
+++ b/luigi.cfg
@@ -7,5 +7,5 @@ logging_conf_file = /etc/luigi/luigi-interface-logger.ini
 
 [scheduler]
 state-path = luigi-state.pickle
-disable_failures = 2
+disable_failures = 10
 disable-window-seconds = 14400


### PR DESCRIPTION
After looking through the documentation, and then looking at the code.. it seems like the best way to avoid long running jobs is to change the disable-window-seconds option in the config files. It's set to use dashes rather than underscores for whatever reason, and there are some mismatches between task and cfg names..
`retry_count == disable_failures`