### PR TITLE
Pin install versions + link to communicating pods luigi versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,11 @@ postgresql-dev \
 git
 
 RUN pip3 install --upgrade pip \
-git+https://github.com/spotify/luigi.git \
-psycopg2 \
-requests \
-SQLAlchemy \
-pyopenssl
+luigi==2.5.0 \
+psycopg2==2.6.2 \
+requests==2.12.5 \
+SQLAlchemy==1.1.5 \
+pyopenssl==16.2.0
 
 RUN rm -rf /var/cache/apk/* && rm -rf /tmp/*
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # Luigi central scheduler
 
-## Communicating ETL Processes
+## ETL Communicating to Luigi Central
 
 ### [etl-adjuster](https://github.com/OAODEV/etl-adjuster)
-* luigi version: https://github.com/OAODEV/etl-adjuster/blob/master/Dockerfile#L18
+* Luigi version: [visible here](https://github.com/OAODEV/etl-adjuster/blob/master/Dockerfile#L18)
 
 ### [etl-autoweb](https://github.com/OAODEV/etl-autoweb)
-* luigi version: https://github.com/OAODEV/etl-autoweb/blob/master/Dockerfile#L18
+* Luigi version: [visible here](https://github.com/OAODEV/etl-autoweb/blob/master/Dockerfile#L18)
 
 ### [etl-dfp](https://github.com/OAODEV/etl-dfp)
-* luigi version: https://github.com/OAODEV/etl-dfp/blob/master/requirements.txt#L3
+* Luigi version: [visible here](https://github.com/OAODEV/etl-dfp/blob/master/requirements.txt#L3)
 
 ### [etl-iadops-mart](https://github.com/OAODEV/etl-iadops-mart)
-* luigi version: https://github.com/OAODEV/etl-iadops-mart/blob/master/Dockerfile#L19
+* Luigi version: [visible here](https://github.com/OAODEV/etl-iadops-mart/blob/master/Dockerfile#L19)
 
 ### [etl-openx](https://github.com/OAODEV/etl-openx)
-* luigi version: https://github.com/OAODEV/etl-openx/blob/master/Dockerfile#L20
+* Luigi version: [visible here](https://github.com/OAODEV/etl-openx/blob/master/Dockerfile#L20)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-#Luigi central scheduler
+# Luigi central scheduler
+
+## Communicating ETL Processes
+
+### [etl-adjuster](https://github.com/OAODEV/etl-adjuster)
+* luigi version: https://github.com/OAODEV/etl-adjuster/blob/master/Dockerfile#L18
+
+### [etl-autoweb](https://github.com/OAODEV/etl-autoweb)
+* luigi version: https://github.com/OAODEV/etl-autoweb/blob/master/Dockerfile#L18
+
+### [etl-dfp](https://github.com/OAODEV/etl-dfp)
+* luigi version: https://github.com/OAODEV/etl-dfp/blob/master/requirements.txt#L3
+
+### [etl-iadops-mart](https://github.com/OAODEV/etl-iadops-mart)
+* luigi version: https://github.com/OAODEV/etl-iadops-mart/blob/master/Dockerfile#L19
+
+### [etl-openx](https://github.com/OAODEV/etl-openx)
+* luigi version: https://github.com/OAODEV/etl-openx/blob/master/Dockerfile#L20

--- a/config-setup.py
+++ b/config-setup.py
@@ -24,5 +24,6 @@ def main():
     else:
         shutil.copyfile('/oao-warehouse-etl/luigi.cfg', '/etc/luigi/luigi.cfg')
 
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Pin versions for central scheduler, and also reference all of the versions of luigi which are running in pods communicating with the central scheduler.